### PR TITLE
Cancel Previous GH Actions

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -1,7 +1,7 @@
 name: Dotnet Framework Tests
 on: [push]
 concurrency: # Cancel previous runs in the same branch
-  group: environment-${{ github.ref }}
+  group: dotnet-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -1,5 +1,8 @@
 name: Dotnet Framework Tests
 on: [push, pull_request]
+concurrency: # Cancel previous runs in the same branch
+group: environment-${{ github.ref }}
+cancel-in-progress: true
 
 jobs:
   run-babelfish-dotnet-tests:

--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -2,8 +2,7 @@ name: Dotnet Framework Tests
 on:
   pull_request:
   push:
-    branches: 
-      - ${{ github.event.repository.default_branch }}
+    branches: [ $default-branch ]
 concurrency: # Cancel previous runs in the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -1,7 +1,11 @@
 name: Dotnet Framework Tests
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: 
+      - ${{ github.event.repository.default_branch }}
 concurrency: # Cancel previous runs in the same branch
-  group: dotnet-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -1,5 +1,5 @@
 name: Dotnet Framework Tests
-on: [push]
+on: [push, pull_request]
 concurrency: # Cancel previous runs in the same branch
   group: dotnet-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -1,5 +1,5 @@
 name: Dotnet Framework Tests
-on: [push, pull_request]
+on: [push]
 concurrency: # Cancel previous runs in the same branch
   group: environment-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -1,8 +1,8 @@
 name: Dotnet Framework Tests
 on: [push, pull_request]
 concurrency: # Cancel previous runs in the same branch
-group: environment-${{ github.ref }}
-cancel-in-progress: true
+  group: environment-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   run-babelfish-dotnet-tests:

--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -2,7 +2,7 @@ name: Dotnet Framework Tests
 on:
   pull_request:
   push:
-    branches: [ $default-branch ]
+    branches: [ 'BABEL_*' ]
 concurrency: # Cancel previous runs in the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/isolation-tests.yml
+++ b/.github/workflows/isolation-tests.yml
@@ -1,9 +1,5 @@
 name: Babelfish Smoke Tests
-on:
-  push:
-    branches:
-  pull_request:
-    branches:
+on: [push]
 concurrency: # Cancel previous runs in the same branch
   group: environment-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/isolation-tests.yml
+++ b/.github/workflows/isolation-tests.yml
@@ -1,7 +1,7 @@
 name: Babelfish Smoke Tests
 on: [push]
 concurrency: # Cancel previous runs in the same branch
-  group: environment-${{ github.ref }}
+  group: smoke-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/isolation-tests.yml
+++ b/.github/workflows/isolation-tests.yml
@@ -2,7 +2,7 @@ name: Babelfish Smoke Tests
 on:
   pull_request:
   push:
-    branches: [ $default-branch ]
+    branches: [ 'BABEL_*' ]
 concurrency: # Cancel previous runs in the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/isolation-tests.yml
+++ b/.github/workflows/isolation-tests.yml
@@ -5,8 +5,8 @@ on:
   pull_request:
     branches:
 concurrency: # Cancel previous runs in the same branch
-group: environment-${{ github.ref }}
-cancel-in-progress: true
+  group: environment-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   isolation-tests:

--- a/.github/workflows/isolation-tests.yml
+++ b/.github/workflows/isolation-tests.yml
@@ -1,7 +1,11 @@
 name: Babelfish Smoke Tests
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: 
+      - ${{ github.event.repository.default_branch }}
 concurrency: # Cancel previous runs in the same branch
-  group: smoke-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/isolation-tests.yml
+++ b/.github/workflows/isolation-tests.yml
@@ -2,8 +2,7 @@ name: Babelfish Smoke Tests
 on:
   pull_request:
   push:
-    branches: 
-      - ${{ github.event.repository.default_branch }}
+    branches: [ $default-branch ]
 concurrency: # Cancel previous runs in the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/isolation-tests.yml
+++ b/.github/workflows/isolation-tests.yml
@@ -4,6 +4,9 @@ on:
     branches:
   pull_request:
     branches:
+concurrency: # Cancel previous runs in the same branch
+group: environment-${{ github.ref }}
+cancel-in-progress: true
 
 jobs:
   isolation-tests:

--- a/.github/workflows/isolation-tests.yml
+++ b/.github/workflows/isolation-tests.yml
@@ -1,5 +1,5 @@
 name: Babelfish Smoke Tests
-on: [push]
+on: [push, pull_request]
 concurrency: # Cancel previous runs in the same branch
   group: smoke-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/jdbc-tests.yml
+++ b/.github/workflows/jdbc-tests.yml
@@ -1,5 +1,5 @@
 name: JDBC Tests
-on: [push, pull_request]
+on: [push]
 concurrency: # Cancel previous runs in the same branch
   group: environment-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/jdbc-tests.yml
+++ b/.github/workflows/jdbc-tests.yml
@@ -2,8 +2,7 @@ name: JDBC Tests
 on:
   pull_request:
   push:
-    branches: 
-      - ${{ github.event.repository.default_branch }}
+    branches: [ $default-branch ]
 concurrency: # Cancel previous runs in the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/jdbc-tests.yml
+++ b/.github/workflows/jdbc-tests.yml
@@ -2,7 +2,7 @@ name: JDBC Tests
 on:
   pull_request:
   push:
-    branches: [ $default-branch ]
+    branches: [ 'BABEL_*' ]
 concurrency: # Cancel previous runs in the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/jdbc-tests.yml
+++ b/.github/workflows/jdbc-tests.yml
@@ -1,8 +1,8 @@
 name: JDBC Tests
 on: [push, pull_request]
 concurrency: # Cancel previous runs in the same branch
-group: environment-${{ github.ref }}
-cancel-in-progress: true
+  group: environment-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   run-babelfish-jdbc-tests:

--- a/.github/workflows/jdbc-tests.yml
+++ b/.github/workflows/jdbc-tests.yml
@@ -1,7 +1,11 @@
 name: JDBC Tests
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: 
+      - ${{ github.event.repository.default_branch }}
 concurrency: # Cancel previous runs in the same branch
-  group: jdbc-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/jdbc-tests.yml
+++ b/.github/workflows/jdbc-tests.yml
@@ -1,7 +1,7 @@
 name: JDBC Tests
 on: [push]
 concurrency: # Cancel previous runs in the same branch
-  group: environment-${{ github.ref }}
+  group: jdbc-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/jdbc-tests.yml
+++ b/.github/workflows/jdbc-tests.yml
@@ -1,5 +1,8 @@
 name: JDBC Tests
 on: [push, pull_request]
+concurrency: # Cancel previous runs in the same branch
+group: environment-${{ github.ref }}
+cancel-in-progress: true
 
 jobs:
   run-babelfish-jdbc-tests:

--- a/.github/workflows/jdbc-tests.yml
+++ b/.github/workflows/jdbc-tests.yml
@@ -1,5 +1,5 @@
 name: JDBC Tests
-on: [push]
+on: [push, pull_request]
 concurrency: # Cancel previous runs in the same branch
   group: jdbc-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -2,8 +2,7 @@ name: Major Version Upgrade Tests for empty database
 on:
   pull_request:
   push:
-    branches: 
-      - ${{ github.event.repository.default_branch }}
+    branches: [ $default-branch ]
 concurrency: # Cancel previous runs in the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -2,7 +2,7 @@ name: Major Version Upgrade Tests for empty database
 on:
   pull_request:
   push:
-    branches: [ $default-branch ]
+    branches: [ 'BABEL_*' ]
 concurrency: # Cancel previous runs in the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -1,5 +1,8 @@
 name: Major Version Upgrade Tests for empty database
 on: [push, pull_request]
+concurrency: # Cancel previous runs in the same branch
+group: environment-${{ github.ref }}
+cancel-in-progress: true
 
 jobs:
   run-babelfish-mvu-tests:

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -1,7 +1,11 @@
 name: Major Version Upgrade Tests for empty database
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: 
+      - ${{ github.event.repository.default_branch }}
 concurrency: # Cancel previous runs in the same branch
-  group: major-upgrade-empty-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -1,7 +1,7 @@
 name: Major Version Upgrade Tests for empty database
 on: [push]
 concurrency: # Cancel previous runs in the same branch
-  group: environment-${{ github.ref }}
+  group: major-upgrade-empty-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -1,8 +1,8 @@
 name: Major Version Upgrade Tests for empty database
 on: [push, pull_request]
 concurrency: # Cancel previous runs in the same branch
-group: environment-${{ github.ref }}
-cancel-in-progress: true
+  group: environment-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   run-babelfish-mvu-tests:

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -1,5 +1,5 @@
 name: Major Version Upgrade Tests for empty database
-on: [push]
+on: [push, pull_request]
 concurrency: # Cancel previous runs in the same branch
   group: major-upgrade-empty-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -1,5 +1,5 @@
 name: Major Version Upgrade Tests for empty database
-on: [push, pull_request]
+on: [push]
 concurrency: # Cancel previous runs in the same branch
   group: environment-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -1,7 +1,7 @@
 name: Minor Version Upgrade Tests for empty database
 on: [push]
 concurrency: # Cancel previous runs in the same branch
-  group: environment-${{ github.ref }}
+  group: minor-upgrade-empty-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -2,7 +2,7 @@ name: Minor Version Upgrade Tests for empty database
 on:
   pull_request:
   push:
-    branches: [ $default-branch ]
+    branches: [ 'BABEL_*' ]
 concurrency: # Cancel previous runs in the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -1,8 +1,8 @@
 name: Minor Version Upgrade Tests for empty database
 on: [push, pull_request]
 concurrency: # Cancel previous runs in the same branch
-group: environment-${{ github.ref }}
-cancel-in-progress: true
+  group: environment-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   extension-tests:

--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -1,5 +1,5 @@
 name: Minor Version Upgrade Tests for empty database
-on: [push]
+on: [push, pull_request]
 concurrency: # Cancel previous runs in the same branch
   group: minor-upgrade-empty-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -1,5 +1,8 @@
 name: Minor Version Upgrade Tests for empty database
 on: [push, pull_request]
+concurrency: # Cancel previous runs in the same branch
+group: environment-${{ github.ref }}
+cancel-in-progress: true
 
 jobs:
   extension-tests:

--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -1,5 +1,5 @@
 name: Minor Version Upgrade Tests for empty database
-on: [push, pull_request]
+on: [push]
 concurrency: # Cancel previous runs in the same branch
   group: environment-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -1,7 +1,11 @@
 name: Minor Version Upgrade Tests for empty database
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: 
+      - ${{ github.event.repository.default_branch }}
 concurrency: # Cancel previous runs in the same branch
-  group: minor-upgrade-empty-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -2,8 +2,7 @@ name: Minor Version Upgrade Tests for empty database
 on:
   pull_request:
   push:
-    branches: 
-      - ${{ github.event.repository.default_branch }}
+    branches: [ $default-branch ]
 concurrency: # Cancel previous runs in the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/odbc-tests.yml
+++ b/.github/workflows/odbc-tests.yml
@@ -1,7 +1,11 @@
 name: ODBC Tests
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: 
+      - ${{ github.event.repository.default_branch }}
 concurrency: # Cancel previous runs in the same branch
-  group: odbc-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/odbc-tests.yml
+++ b/.github/workflows/odbc-tests.yml
@@ -1,5 +1,8 @@
 name: ODBC Tests
 on: [push, pull_request]
+concurrency: # Cancel previous runs in the same branch
+group: environment-${{ github.ref }}
+cancel-in-progress: true
 
 jobs:
   run-babelfish-odbc-tests:

--- a/.github/workflows/odbc-tests.yml
+++ b/.github/workflows/odbc-tests.yml
@@ -1,8 +1,8 @@
 name: ODBC Tests
 on: [push, pull_request]
 concurrency: # Cancel previous runs in the same branch
-group: environment-${{ github.ref }}
-cancel-in-progress: true
+  group: environment-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   run-babelfish-odbc-tests:

--- a/.github/workflows/odbc-tests.yml
+++ b/.github/workflows/odbc-tests.yml
@@ -1,5 +1,5 @@
 name: ODBC Tests
-on: [push, pull_request]
+on: [push]
 concurrency: # Cancel previous runs in the same branch
   group: environment-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/odbc-tests.yml
+++ b/.github/workflows/odbc-tests.yml
@@ -1,5 +1,5 @@
 name: ODBC Tests
-on: [push]
+on: [push, pull_request]
 concurrency: # Cancel previous runs in the same branch
   group: odbc-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/odbc-tests.yml
+++ b/.github/workflows/odbc-tests.yml
@@ -2,7 +2,7 @@ name: ODBC Tests
 on:
   pull_request:
   push:
-    branches: [ $default-branch ]
+    branches: [ 'BABEL_*' ]
 concurrency: # Cancel previous runs in the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/odbc-tests.yml
+++ b/.github/workflows/odbc-tests.yml
@@ -1,7 +1,7 @@
 name: ODBC Tests
 on: [push]
 concurrency: # Cancel previous runs in the same branch
-  group: environment-${{ github.ref }}
+  group: odbc-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/odbc-tests.yml
+++ b/.github/workflows/odbc-tests.yml
@@ -2,8 +2,7 @@ name: ODBC Tests
 on:
   pull_request:
   push:
-    branches: 
-      - ${{ github.event.repository.default_branch }}
+    branches: [ $default-branch ]
 concurrency: # Cancel previous runs in the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pg-hint-plan-tests.yml
+++ b/.github/workflows/pg-hint-plan-tests.yml
@@ -1,7 +1,7 @@
 name: pg-hint-plan Tests
 on: [push]
 concurrency: # Cancel previous runs in the same branch
-  group: environment-${{ github.ref }}
+  group: pg-hint-plan-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pg-hint-plan-tests.yml
+++ b/.github/workflows/pg-hint-plan-tests.yml
@@ -1,7 +1,11 @@
 name: pg-hint-plan Tests
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: 
+      - ${{ github.event.repository.default_branch }}
 concurrency: # Cancel previous runs in the same branch
-  group: pg-hint-plan-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pg-hint-plan-tests.yml
+++ b/.github/workflows/pg-hint-plan-tests.yml
@@ -1,5 +1,8 @@
 name: pg-hint-plan Tests
 on: [push, pull_request]
+concurrency: # Cancel previous runs in the same branch
+group: environment-${{ github.ref }}
+cancel-in-progress: true
 
 jobs:
   run-pg-hint-plan-tests:

--- a/.github/workflows/pg-hint-plan-tests.yml
+++ b/.github/workflows/pg-hint-plan-tests.yml
@@ -1,5 +1,5 @@
 name: pg-hint-plan Tests
-on: [push, pull_request]
+on: [push]
 concurrency: # Cancel previous runs in the same branch
   group: environment-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pg-hint-plan-tests.yml
+++ b/.github/workflows/pg-hint-plan-tests.yml
@@ -1,5 +1,5 @@
 name: pg-hint-plan Tests
-on: [push]
+on: [push, pull_request]
 concurrency: # Cancel previous runs in the same branch
   group: pg-hint-plan-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pg-hint-plan-tests.yml
+++ b/.github/workflows/pg-hint-plan-tests.yml
@@ -2,8 +2,7 @@ name: pg-hint-plan Tests
 on:
   pull_request:
   push:
-    branches: 
-      - ${{ github.event.repository.default_branch }}
+    branches: [ $default-branch ]
 concurrency: # Cancel previous runs in the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pg-hint-plan-tests.yml
+++ b/.github/workflows/pg-hint-plan-tests.yml
@@ -2,7 +2,7 @@ name: pg-hint-plan Tests
 on:
   pull_request:
   push:
-    branches: [ $default-branch ]
+    branches: [ 'BABEL_*' ]
 concurrency: # Cancel previous runs in the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pg-hint-plan-tests.yml
+++ b/.github/workflows/pg-hint-plan-tests.yml
@@ -1,8 +1,8 @@
 name: pg-hint-plan Tests
 on: [push, pull_request]
 concurrency: # Cancel previous runs in the same branch
-group: environment-${{ github.ref }}
-cancel-in-progress: true
+  group: environment-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   run-pg-hint-plan-tests:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,8 +1,8 @@
 name: Python Tests
 on: [push, pull_request]
 concurrency: # Cancel previous runs in the same branch
-group: environment-${{ github.ref }}
-cancel-in-progress: true
+  group: environment-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   run-babelfish-python-tests:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -2,7 +2,7 @@ name: Python Tests
 on:
   pull_request:
   push:
-    branches: [ $default-branch ]
+    branches: [ 'BABEL_*' ]
 concurrency: # Cancel previous runs in the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,5 +1,8 @@
 name: Python Tests
 on: [push, pull_request]
+concurrency: # Cancel previous runs in the same branch
+group: environment-${{ github.ref }}
+cancel-in-progress: true
 
 jobs:
   run-babelfish-python-tests:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -2,8 +2,7 @@ name: Python Tests
 on:
   pull_request:
   push:
-    branches: 
-      - ${{ github.event.repository.default_branch }}
+    branches: [ $default-branch ]
 concurrency: # Cancel previous runs in the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,7 +1,11 @@
 name: Python Tests
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: 
+      - ${{ github.event.repository.default_branch }}
 concurrency: # Cancel previous runs in the same branch
-  group: python-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,7 +1,7 @@
 name: Python Tests
 on: [push]
 concurrency: # Cancel previous runs in the same branch
-  group: environment-${{ github.ref }}
+  group: python-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,5 +1,5 @@
 name: Python Tests
-on: [push, pull_request]
+on: [push]
 concurrency: # Cancel previous runs in the same branch
   group: environment-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,5 +1,5 @@
 name: Python Tests
-on: [push]
+on: [push, pull_request]
 concurrency: # Cancel previous runs in the same branch
   group: python-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/singledb-version-upgrade.yml
+++ b/.github/workflows/singledb-version-upgrade.yml
@@ -1,7 +1,11 @@
 name: Major Version Upgrade Tests for singledb mode
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: 
+      - ${{ github.event.repository.default_branch }}
 concurrency: # Cancel previous runs in the same branch
-  group: singledb-upgrade-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/singledb-version-upgrade.yml
+++ b/.github/workflows/singledb-version-upgrade.yml
@@ -1,5 +1,5 @@
 name: Major Version Upgrade Tests for singledb mode
-on: [push]
+on: [push, pull_request]
 concurrency: # Cancel previous runs in the same branch
   group: singledb-upgrade-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/singledb-version-upgrade.yml
+++ b/.github/workflows/singledb-version-upgrade.yml
@@ -1,5 +1,8 @@
 name: Major Version Upgrade Tests for singledb mode
 on: [push, pull_request]
+concurrency: # Cancel previous runs in the same branch
+group: environment-${{ github.ref }}
+cancel-in-progress: true
 
 jobs:
   run-babelfish-mvu-tests-singledb:

--- a/.github/workflows/singledb-version-upgrade.yml
+++ b/.github/workflows/singledb-version-upgrade.yml
@@ -1,7 +1,7 @@
 name: Major Version Upgrade Tests for singledb mode
 on: [push]
 concurrency: # Cancel previous runs in the same branch
-  group: environment-${{ github.ref }}
+  group: singledb-upgrade-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/singledb-version-upgrade.yml
+++ b/.github/workflows/singledb-version-upgrade.yml
@@ -1,8 +1,8 @@
 name: Major Version Upgrade Tests for singledb mode
 on: [push, pull_request]
 concurrency: # Cancel previous runs in the same branch
-group: environment-${{ github.ref }}
-cancel-in-progress: true
+  group: environment-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   run-babelfish-mvu-tests-singledb:

--- a/.github/workflows/singledb-version-upgrade.yml
+++ b/.github/workflows/singledb-version-upgrade.yml
@@ -1,5 +1,5 @@
 name: Major Version Upgrade Tests for singledb mode
-on: [push, pull_request]
+on: [push]
 concurrency: # Cancel previous runs in the same branch
   group: environment-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/singledb-version-upgrade.yml
+++ b/.github/workflows/singledb-version-upgrade.yml
@@ -2,8 +2,7 @@ name: Major Version Upgrade Tests for singledb mode
 on:
   pull_request:
   push:
-    branches: 
-      - ${{ github.event.repository.default_branch }}
+    branches: [ $default-branch ]
 concurrency: # Cancel previous runs in the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/singledb-version-upgrade.yml
+++ b/.github/workflows/singledb-version-upgrade.yml
@@ -2,7 +2,7 @@ name: Major Version Upgrade Tests for singledb mode
 on:
   pull_request:
   push:
-    branches: [ $default-branch ]
+    branches: [ 'BABEL_*' ]
 concurrency: # Cancel previous runs in the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/sql-validation-tests.yml
+++ b/.github/workflows/sql-validation-tests.yml
@@ -1,5 +1,5 @@
 name: Validate Installation/Upgrade Scripts
-on: [push]
+on: [push, pull_request]
 concurrency: # Cancel previous runs in the same branch
   group: validate-upgrade-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/sql-validation-tests.yml
+++ b/.github/workflows/sql-validation-tests.yml
@@ -2,7 +2,7 @@ name: Validate Installation/Upgrade Scripts
 on:
   pull_request:
   push:
-    branches: [ $default-branch ]
+    branches: [ 'BABEL_*' ]
 concurrency: # Cancel previous runs in the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/sql-validation-tests.yml
+++ b/.github/workflows/sql-validation-tests.yml
@@ -1,7 +1,11 @@
 name: Validate Installation/Upgrade Scripts
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: 
+      - ${{ github.event.repository.default_branch }}
 concurrency: # Cancel previous runs in the same branch
-  group: validate-upgrade-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/sql-validation-tests.yml
+++ b/.github/workflows/sql-validation-tests.yml
@@ -2,8 +2,7 @@ name: Validate Installation/Upgrade Scripts
 on:
   pull_request:
   push:
-    branches: 
-      - ${{ github.event.repository.default_branch }}
+    branches: [ $default-branch ]
 concurrency: # Cancel previous runs in the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/sql-validation-tests.yml
+++ b/.github/workflows/sql-validation-tests.yml
@@ -1,8 +1,8 @@
 name: Validate Installation/Upgrade Scripts
 on: [push, pull_request]
 concurrency: # Cancel previous runs in the same branch
-group: environment-${{ github.ref }}
-cancel-in-progress: true
+  group: environment-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   run-sql-validation-tests:

--- a/.github/workflows/sql-validation-tests.yml
+++ b/.github/workflows/sql-validation-tests.yml
@@ -1,5 +1,8 @@
 name: Validate Installation/Upgrade Scripts
 on: [push, pull_request]
+concurrency: # Cancel previous runs in the same branch
+group: environment-${{ github.ref }}
+cancel-in-progress: true
 
 jobs:
   run-sql-validation-tests:

--- a/.github/workflows/sql-validation-tests.yml
+++ b/.github/workflows/sql-validation-tests.yml
@@ -1,5 +1,5 @@
 name: Validate Installation/Upgrade Scripts
-on: [push, pull_request]
+on: [push]
 concurrency: # Cancel previous runs in the same branch
   group: environment-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/sql-validation-tests.yml
+++ b/.github/workflows/sql-validation-tests.yml
@@ -1,7 +1,7 @@
 name: Validate Installation/Upgrade Scripts
 on: [push]
 concurrency: # Cancel previous runs in the same branch
-  group: environment-${{ github.ref }}
+  group: validate-upgrade-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -2,7 +2,7 @@ name: Version Upgrade Test Framework
 on:
   pull_request:
   push:
-    branches: [ $default-branch ]
+    branches: [ 'BABEL_*' ]
 concurrency: # Cancel previous runs in the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -1,7 +1,11 @@
 name: Version Upgrade Test Framework
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: 
+      - ${{ github.event.repository.default_branch }}
 concurrency: # Cancel previous runs in the same branch
-  group: version-upgrade-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -1,8 +1,8 @@
 name: Version Upgrade Test Framework
 on: [push, pull_request]
 concurrency: # Cancel previous runs in the same branch
-group: environment-${{ github.ref }}
-cancel-in-progress: true
+  group: environment-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   generate-version-upgrade-tests:

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -1,5 +1,5 @@
 name: Version Upgrade Test Framework
-on: [push]
+on: [push, pull_request]
 concurrency: # Cancel previous runs in the same branch
   group: version-upgrade-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -1,5 +1,5 @@
 name: Version Upgrade Test Framework
-on: [push, pull_request]
+on: [push]
 concurrency: # Cancel previous runs in the same branch
   group: environment-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -1,5 +1,8 @@
 name: Version Upgrade Test Framework
 on: [push, pull_request]
+concurrency: # Cancel previous runs in the same branch
+group: environment-${{ github.ref }}
+cancel-in-progress: true
 
 jobs:
   generate-version-upgrade-tests:

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -1,7 +1,7 @@
 name: Version Upgrade Test Framework
 on: [push]
 concurrency: # Cancel previous runs in the same branch
-  group: environment-${{ github.ref }}
+  group: version-upgrade-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -2,8 +2,7 @@ name: Version Upgrade Test Framework
 on:
   pull_request:
   push:
-    branches: 
-      - ${{ github.event.repository.default_branch }}
+    branches: [ $default-branch ]
 concurrency: # Cancel previous runs in the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
### Description

Cancels previous GH Action workflows in the same branch when there is a new commit to it.

Some things of note
- It runs on whenever a PR is created / has a new push
- It runs whenever a branch with the following prefix `BABEL_*` is pushed to
 
### Issues Resolved
n/a


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).